### PR TITLE
Add method to download a range of days

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,3 +4,14 @@ import-order-style = smarkets
 inline-quotes = double
 max-complexity = 10
 multiline-quotes = double
+max-line-length = 88
+# W503: Line break occurred before a binary operator
+# E203: Whitespace before ':'
+# D202 No blank lines allowed after function docstring
+# W504 line break after binary operator
+ignore =
+    W503,
+    E203,
+    D202,
+    W504,
+    PIE782

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
     hooks:
       - id: flake8
         name: Lint code (flake8)
-        args: ['--ignore=W503,PIE782']
         additional_dependencies:
           - flake8==3.7.9
           - flake8-broken-line==0.1.1

--- a/aiopvpc/__init__.py
+++ b/aiopvpc/__init__.py
@@ -1,9 +1,22 @@
 """Simple aio library to download Spanish electricity hourly prices."""
-from .pvpc_data import (
+from .pvpc_data import PVPCData
+from .pvpc_download import (
     DEFAULT_TIMEOUT,
-    PVPCData,
+    ESIOS_TARIFFS,
+    extract_pvpc_data,
+    get_url_for_daily_json,
     REFERENCE_TZ,
+    TARIFF_KEYS,
     TARIFFS,
 )
 
-__all__ = ("DEFAULT_TIMEOUT", "PVPCData", "REFERENCE_TZ", "TARIFFS")
+__all__ = (
+    "DEFAULT_TIMEOUT",
+    "ESIOS_TARIFFS",
+    "extract_pvpc_data",
+    "get_url_for_daily_json",
+    "PVPCData",
+    "REFERENCE_TZ",
+    "TARIFF_KEYS",
+    "TARIFFS",
+)

--- a/aiopvpc/pvpc_data.py
+++ b/aiopvpc/pvpc_data.py
@@ -94,9 +94,7 @@ class PVPCData:
             self._logger.debug("Bad try on getting prices for %s", day)
         except asyncio.TimeoutError:
             if self.source_available:
-                self._logger.warning(
-                    "Timeout error requesting data from '%s'", url
-                )
+                self._logger.warning("Timeout error requesting data from '%s'", url)
         except aiohttp.ClientError:
             if self.source_available:
                 self._logger.warning("Client error in '%s'", url)
@@ -144,9 +142,7 @@ class PVPCData:
         if len(self._current_prices) > 25 and actual_time.hour < 20:
             # there are 'today' and 'next day' prices, but 'today' has expired
             max_age = (
-                utc_time.astimezone(REFERENCE_TZ)
-                .replace(hour=0)
-                .astimezone(pytz.UTC)
+                utc_time.astimezone(REFERENCE_TZ).replace(hour=0).astimezone(pytz.UTC)
             )
             self._current_prices = {
                 key_ts: price
@@ -164,9 +160,7 @@ class PVPCData:
             return False
 
         # generate sensor attributes
-        prices_sorted = dict(
-            sorted(self._current_prices.items(), key=lambda x: x[1])
-        )
+        prices_sorted = dict(sorted(self._current_prices.items(), key=lambda x: x[1]))
         attributes["min_price"] = min(self._current_prices.values())
         attributes["min_price_at"] = _local(next(iter(prices_sorted))).hour
         attributes["next_best_at"] = list(

--- a/aiopvpc/pvpc_data.py
+++ b/aiopvpc/pvpc_data.py
@@ -8,7 +8,8 @@ https://www.home-assistant.io/integrations/pvpc_hourly_pricing/
 import asyncio
 import logging
 from datetime import date, datetime, timedelta
-from typing import Dict, Optional
+from time import monotonic
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import aiohttp
 import async_timeout
@@ -31,13 +32,21 @@ class PVPCData:
 
     * Async download of prices for each day
     * Generate state attributes for HA integration.
+    * Async download of prices for a range of days
+
+    - Prices are returned in a `Dict[datetime, float]`,
+    with timestamps in UTC and prices in €/kWh.
+
+    - Without a specific `tariff`, it would return the entire collection
+    of PVPC data, without any unit conversion,
+    and type `Dict[datetime, Dict[str, float]`.
     """
 
     def __init__(
         self,
-        tariff: str,
-        websession: aiohttp.ClientSession,
-        local_timezone: pytz.BaseTzInfo,
+        tariff: Optional[str] = None,
+        websession: Optional[aiohttp.ClientSession] = None,
+        local_timezone: pytz.tzinfo.DstTzInfo = REFERENCE_TZ,
         logger: Optional[logging.Logger] = None,
         timeout: float = DEFAULT_TIMEOUT,
     ):
@@ -49,13 +58,17 @@ class PVPCData:
         self.tariff = tariff
         self.timeout = timeout
 
+        self._session = websession
+        self._with_initial_session = websession is not None
         self._local_timezone = local_timezone
-        self._websession = websession
         self._logger = logger or logging.getLogger(__name__)
 
         self._current_prices: Dict[datetime, float] = {}
 
-    async def _download_pvpc_prices(self, day: date) -> Dict[datetime, float]:
+        if tariff is None or tariff not in TARIFF_KEYS:
+            self._logger.warning("Collecting detailed PVPC data for all tariffs")
+
+    async def _download_pvpc_prices(self, day: date) -> Dict[datetime, Any]:
         """
         PVPC data extractor.
 
@@ -70,7 +83,7 @@ class PVPCData:
         url = get_url_for_daily_json(day)
         try:
             with async_timeout.timeout(self.timeout):
-                resp = await self._websession.get(url)
+                resp = await self._session.get(url)
                 if resp.status < 400:
                     data = await resp.json()
                     pvpc_data = extract_pvpc_data(data, TARIFF_KEYS.get(self.tariff))
@@ -85,7 +98,7 @@ class PVPCData:
                 self._logger.warning("Client error in '%s'", url)
         return {}
 
-    async def async_update_prices(self, now: datetime):
+    async def async_update_prices(self, now: datetime) -> Dict[datetime, float]:
         """Update electricity prices from the ESIOS API."""
         localized_now = now.astimezone(pytz.UTC).astimezone(REFERENCE_TZ)
         prices = await self._download_pvpc_prices(localized_now.date())
@@ -168,3 +181,120 @@ class PVPCData:
 
         self.attributes = attributes
         return True
+
+    async def _download_worker(self, wk_name: str, queue: asyncio.Queue):
+        downloaded_prices = []
+        try:
+            while True:
+                day: date = await queue.get()
+                tic = monotonic()
+                prices = await self._download_pvpc_prices(day)
+                took = monotonic() - tic
+                queue.task_done()
+                if not prices:
+                    self._logger.warning(
+                        "[%s]: Bad download for day: %s in %.3f s", wk_name, day, took
+                    )
+                    continue
+
+                downloaded_prices.append((day, prices))
+                self._logger.debug(
+                    "[%s]: Task done for day: %s in %.3f s", wk_name, day, took
+                )
+        except asyncio.CancelledError:
+            return downloaded_prices
+
+    async def _multi_download(
+        self, days_to_download: List[date], max_calls: int
+    ) -> Iterable[Tuple[date, Dict[datetime, Any]]]:
+        """Multiple requests using an asyncio.Queue for concurrency."""
+        queue = asyncio.Queue()
+        # setup `max_calls` queue workers
+        worker_tasks = [
+            asyncio.create_task(self._download_worker(f"worker-{i+1}", queue))
+            for i in range(max_calls)
+        ]
+        # fill queue
+        for day in days_to_download:
+            queue.put_nowait(day)
+
+        # wait for the queue to process all
+        await queue.join()
+
+        for task in worker_tasks:
+            task.cancel()
+        # Wait until all worker tasks are cancelled.
+        wk_tasks_results = await asyncio.gather(*worker_tasks, return_exceptions=True)
+
+        return sorted(
+            (day_data for wk_results in wk_tasks_results for day_data in wk_results),
+            key=lambda x: x[0],
+        )
+
+    async def _ensure_session(self):
+        if self._session is None:
+            assert not self._with_initial_session
+            self._session = aiohttp.ClientSession()
+
+    async def _close_temporal_session(self):
+        if not self._with_initial_session and self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    async def async_download_prices_for_range(
+        self, start: datetime, end: datetime, concurrency_calls: int = 20
+    ) -> Dict[datetime, Any]:
+        """Download a time range burst of electricity prices from the ESIOS API."""
+
+        def _adjust_dates(ts: datetime) -> Tuple[datetime, datetime]:
+            # adjust dates and tz from inputs
+            if ts.tzinfo is None:
+                ts = self._local_timezone.localize(ts)
+            ts_utc = ts.astimezone(pytz.UTC)
+            ts_ref = ts_utc.astimezone(REFERENCE_TZ)
+            return ts_utc, ts_ref
+
+        start_utc, start_local = _adjust_dates(start)
+        end_utc, end_local = _adjust_dates(end)
+        delta: timedelta = end_local.date() - start_local.date()
+        days_to_download = [
+            start_local.date() + timedelta(days=i) for i in range(delta.days + 1)
+        ]
+
+        tic = monotonic()
+        max_calls = concurrency_calls
+        await self._ensure_session()
+        data_days = await self._multi_download(days_to_download, max_calls)
+        await self._close_temporal_session()
+
+        prices = {
+            hour: hourly_data[hour]
+            for (day, hourly_data) in data_days
+            for hour in hourly_data
+            if start_utc <= hour <= end_utc
+        }
+        if prices:
+            self._logger.warning(
+                "Download of %d prices from %s to %s in %.2f sec",
+                len(prices),
+                min(prices),
+                max(prices),
+                monotonic() - tic,
+            )
+        else:
+            self._logger.error(
+                "BAD Download of PVPC prices from %s to %s in %.2f sec",
+                start,
+                end,
+                monotonic() - tic,
+            )
+
+        return prices
+
+    def download_prices_for_range(
+        self, start: datetime, end: datetime, concurrency_calls: int = 20
+    ) -> Dict[datetime, Any]:
+        """Blocking method to download a time range burst of elec prices."""
+        return asyncio.run(
+            self.async_download_prices_for_range(start, end, concurrency_calls)
+        )

--- a/aiopvpc/pvpc_download.py
+++ b/aiopvpc/pvpc_download.py
@@ -1,0 +1,62 @@
+"""
+Simple aio library to download Spanish electricity hourly prices.
+
+* URL for JSON daily files
+* Parser for the contents of the JSON files
+"""
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, Optional, Union
+
+import pytz
+
+# Tariffs as internal keys in esios API data
+ESIOS_TARIFFS = ["GEN", "NOC", "VHC"]
+
+# Tariffs used in HomeAssistant integration
+TARIFFS = ["normal", "discrimination", "electric_car"]
+TARIFF_KEYS = dict(zip(TARIFFS, ESIOS_TARIFFS))
+
+# Prices are given in 0 to 24h sets, adjusted to the main timezone in Spain
+REFERENCE_TZ = pytz.timezone("Europe/Madrid")
+
+DEFAULT_TIMEOUT = 5
+_PRECISION = 5
+_RESOURCE = (
+    "https://api.esios.ree.es/archives/70/download_json"
+    "?locale=es&date={day:%Y-%m-%d}"
+)
+
+
+def get_url_for_daily_json(day: Union[date, datetime]) -> str:
+    """Get URL for JSON file with PVPC data for a specific day (in Europe/Madrid TZ)."""
+    return _RESOURCE.format(day=day)
+
+
+def extract_pvpc_data(
+    data: Dict[str, Any], key: Optional[str] = None
+) -> Union[Dict[datetime, float], Dict[datetime, Dict[str, float]]]:
+    """Parse the contents of a daily PVPC json file."""
+    ts_init = REFERENCE_TZ.localize(
+        datetime.strptime(data["PVPC"][0]["Dia"], "%d/%m/%Y"),
+        is_dst=False,  # dst change is never at 00:00
+    ).astimezone(pytz.UTC)
+
+    def _parse_tariff_val(value, prec=_PRECISION) -> float:
+        return round(float(value.replace(",", ".")) / 1000.0, prec)
+
+    def _parse_val(value) -> float:
+        return float(value.replace(",", "."))
+
+    if key is not None:
+        return {
+            ts_init + timedelta(hours=i): _parse_tariff_val(values_hour[key])
+            for i, values_hour in enumerate(data["PVPC"])
+        }
+
+    return {
+        ts_init
+        + timedelta(hours=i): {
+            k: _parse_val(v) for k, v in values_hour.items() if k not in ("Dia", "Hora")
+        }
+        for i, values_hour in enumerate(data["PVPC"])
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
-line_length = 79
-target_version = ["py37"]
+line_length = 88
+target_version = ["py37", "py38"]
 
 [tool.coverage.run]
 branch = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,19 @@ class MockAsyncSession:
     _counter: int = 0
     _raw_response = None
 
+    def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def __await__(self):
+        yield
+        return self
+
+    async def close(self, *_args):
+        pass
+
     def __init__(self, status=200, exc=None):
         """Set up desired mock response"""
         self._raw_response = _DEFAULT_EMPTY_VALUE

--- a/tests/test_pvpc.py
+++ b/tests/test_pvpc.py
@@ -2,12 +2,13 @@
 import logging
 from asyncio import TimeoutError
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pytest
 import pytz
 from aiohttp import ClientError
 
-from aiopvpc import PVPCData, REFERENCE_TZ
+from aiopvpc import ESIOS_TARIFFS, PVPCData, REFERENCE_TZ
 from .conftest import MockAsyncSession
 
 _TZ_TEST = pytz.timezone("Atlantic/Canary")
@@ -76,3 +77,55 @@ async def test_bad_downloads(
         assert len(caplog.messages) == num_log_msgs
     assert mock_session.call_count == 1
     assert len(prices) == 0
+
+
+def test_full_data_download_range():
+    """Test retrieval of full PVPC data in a day range."""
+    start = _TZ_TEST.localize(datetime(2019, 10, 26, 15))
+    end = _TZ_TEST.localize(datetime(2019, 10, 27, 13))
+
+    with patch("aiohttp.ClientSession", MockAsyncSession):
+        pvpc_data = PVPCData()
+        prices = pvpc_data.download_prices_for_range(start, end)
+
+    assert len(prices) == 24
+    first_price = min(prices)
+    last_price = max(prices)
+    assert first_price.hour == 14 and first_price.tzname() == "UTC"
+    assert last_price.hour == 13 and last_price.tzname() == "UTC"
+    data_first_hour = prices[first_price]
+
+    # Check full PVPC data is retrieved
+    assert len(data_first_hour) == 30
+    assert all(tag in data_first_hour for tag in ESIOS_TARIFFS)
+
+    # Check units have not changed in full data retrieval (they are in €/MWh)
+    assert all(data_first_hour[tag] > 1 for tag in ESIOS_TARIFFS)
+
+
+async def test_download_range(caplog):
+    """Test retrieval of full PVPC data in a day range."""
+    start = datetime(2019, 10, 26, 15)
+    end = datetime(2019, 10, 28, 13)
+    mock_session = MockAsyncSession()
+
+    with caplog.at_level(logging.WARNING):
+        pvpc_data = PVPCData(
+            tariff="electric_car", local_timezone=_TZ_TEST, websession=mock_session
+        )
+        prices = await pvpc_data.async_download_prices_for_range(start, end)
+        assert mock_session.call_count == 3
+        assert len(prices) == 33
+        assert len(caplog.messages) == 2
+
+        no_prices = await pvpc_data.async_download_prices_for_range(
+            datetime(2010, 8, 26, 23), datetime(2010, 8, 27, 22)
+        )
+        assert len(no_prices) == 0
+        assert len(caplog.messages) == 4
+
+    first_price = min(prices)
+    assert first_price.hour == 14 and first_price.tzname() == "UTC"
+    # Check only tariff values are retrieved
+    assert isinstance(prices[first_price], float)
+    assert prices[first_price] < 1

--- a/tests/test_pvpc.py
+++ b/tests/test_pvpc.py
@@ -30,9 +30,7 @@ async def test_price_extract(
     mock_session = MockAsyncSession()
 
     pvpc_data = PVPCData(
-        local_timezone=_TZ_TEST,
-        tariff="discrimination",
-        websession=mock_session,
+        local_timezone=_TZ_TEST, tariff="discrimination", websession=mock_session,
     )
 
     pvpc_data.source_available = True
@@ -44,9 +42,7 @@ async def test_price_extract(
     assert mock_session.call_count == num_calls
     assert has_prices
 
-    has_prices = pvpc_data.process_state_and_attributes(
-        day + timedelta(hours=10)
-    )
+    has_prices = pvpc_data.process_state_and_attributes(day + timedelta(hours=10))
     assert len(pvpc_data._current_prices) == num_prices_8h
     assert has_prices == available_8h
 
@@ -70,9 +66,7 @@ async def test_bad_downloads(
     mock_session = MockAsyncSession(status=status, exc=exception)
     with caplog.at_level(logging.DEBUG):
         pvpc_data = PVPCData(
-            local_timezone=REFERENCE_TZ,
-            tariff="normal",
-            websession=mock_session,
+            local_timezone=REFERENCE_TZ, tariff="normal", websession=mock_session,
         )
         pvpc_data.source_available = available
         assert not pvpc_data.process_state_and_attributes(day)

--- a/tests/test_real_api_calls.py
+++ b/tests/test_real_api_calls.py
@@ -1,0 +1,54 @@
+"""Tests for aiopvpc."""
+from datetime import datetime
+
+import pytest
+import pytz
+from aiohttp import ClientSession
+
+from aiopvpc import PVPCData
+
+_TZ_TEST = pytz.timezone("Atlantic/Canary")
+
+
+@pytest.mark.skip("Real call to ESIOS API")
+def test_real_download_range():
+    # No async
+    pvpc_handler = PVPCData("normal")
+    start = datetime(2019, 10, 26, 15)
+    end = datetime(2019, 10, 28, 13)
+    prices = pvpc_handler.download_prices_for_range(start, end)
+    assert len(prices) == 48
+
+    no_prices = pvpc_handler.download_prices_for_range(
+        datetime(2010, 8, 26, 23), datetime(2010, 8, 27, 22)
+    )
+    assert len(no_prices) == 0
+
+
+@pytest.mark.skip("Real call to ESIOS API")
+async def test_real_download_range_async():
+    start = datetime(2019, 10, 26, 15)
+    end = datetime(2019, 10, 28, 13)
+    async with ClientSession() as session:
+        pvpc_handler = PVPCData("normal", websession=session)
+        prices = await pvpc_handler.async_download_prices_for_range(start, end)
+    assert len(prices) == 48
+
+    # without session also works, creating one for each download range call
+    pvpc_handler_no_s = PVPCData("normal")
+    prices2 = await pvpc_handler_no_s.async_download_prices_for_range(start, end)
+    assert len(prices2) == 48
+    assert prices == prices2
+
+
+@pytest.mark.skip("Real call to ESIOS API")
+async def test_real_download_today_async():
+    async with ClientSession() as session:
+        pvpc_handler = PVPCData("discriminacion", websession=session)
+        prices = await pvpc_handler.async_update_prices(datetime.utcnow())
+    assert 22 < len(prices) < 49
+
+    # Check error without session
+    pvpc_handler_bad = PVPCData("discriminacion")
+    with pytest.raises(AttributeError):
+        await pvpc_handler_bad.async_update_prices(datetime.utcnow())


### PR DESCRIPTION
Add methods to download a range of days of PVPC data

* Async & blocking download of prices for a range of days.
* Make specific tariff optional, to get **ALL PVPC detailed data** when `None`, with schema `Dict[datetime, Dict[str, float]` instead of tariff-specific `Dict[datetime, float]`.
* Make rest of init parameters also optional, to easier instantiation with `PVPCData()`.
* Use an `asyncio.Queue` to control concurrency for downloading a bunch of days, by creating a `concurrency_calls` number of workers.