### PR TITLE
🐛 Process 403 error from server like '401 unauthorized'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v4.1.0](https://github.com/azogue/aiopvpc/tree/v4.0.1) - Adapt to 403 unauthorized error (2023-03-12)
+
+[Full Changelog](https://github.com/azogue/aiopvpc/compare/v4.1.0...v4.0.1)
+
+- 🐛 Process 403 error from server like '401 unauthorized', raising `BadApiTokenAuthError`
+  to signal HA for reauth-config for both status codes, when API token is enabled.
+
 ## [v4.0.1](https://github.com/azogue/aiopvpc/tree/v4.0.1) - Minor fixes (2023-01-11)
 
 [Full Changelog](https://github.com/azogue/aiopvpc/compare/v4.0.1...v4.0.0)

--- a/aiopvpc/pvpc_data.py
+++ b/aiopvpc/pvpc_data.py
@@ -137,7 +137,7 @@ class PVPCData:
             return extract_esios_data(
                 data, url, sensor_key, self.tariff, tz=self._local_timezone
             )
-        elif resp.status == 401 and self._data_source == "esios":
+        elif resp.status in (401, 403) and self._data_source == "esios":
             _LOGGER.warning(
                 "[%s] Unauthorized error with '%s': %s",
                 sensor_key,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ markers = [
 
 [tool.poetry]
 name = "aiopvpc"
-version = "4.0.1"
+version = "4.1.0"
 description = "Retrieval of Spanish Electricity hourly prices (PVPC)"
 authors = ["Eugenio Panadero <eugenio.panadero@gmail.com>"]
 license = "MIT"

--- a/tests/test_pvpc.py
+++ b/tests/test_pvpc.py
@@ -26,6 +26,7 @@ from tests.conftest import check_num_datapoints, MockAsyncSession, run_h_step, T
     (
         ("esios_public", None, "2032-10-26", 0, 200, None),
         ("esios_public", None, "2032-10-26", 1, 500, None),
+        ("esios", "bad-token", "2032-10-26", 1, 403, None),
         ("esios", "bad-token", "2032-10-26", 1, 401, None),
         ("esios_public", None, "2032-10-26", 1, 200, TimeoutError),
         ("esios_public", None, "2032-10-26", 1, 200, ClientError),
@@ -50,7 +51,7 @@ async def test_bad_downloads(
             data_source=cast(DataSource, data_source),
             api_token=api_token,
         )
-        if status == 401:
+        if status in (401, 403):
             with pytest.raises(BadApiTokenAuthError):
                 await pvpc_data.async_update_all(None, day)
             assert mock_session.call_count == 1


### PR DESCRIPTION
raising `BadApiTokenAuthError` to signal HA for reauth-config for both status codes,
 when API token is enabled.