### PR TITLE
Remove python upper limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ readme = "README.md"
 repository = "https://github.com/azogue/aiopvpc"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.12"
+python = ">=3.9"
 aiohttp = ">=3.7.4.post0"
 async_timeout = ">=3.0.1"
 


### PR DESCRIPTION
An upper limit for `python` blocks any attempt to install and test this package for new python versions like `3.12`. Even if it doesn't technically work with those yet.

The recommendation for the `python` pin is usually to only use a lower bound.