### PR TITLE
Indicador de ajuste de mercado y cálculo de Indexada

### DIFF
--- a/aiopvpc/const.py
+++ b/aiopvpc/const.py
@@ -54,6 +54,7 @@ ESIOS_INJECTION = "1739"
 ESIOS_MAG = "1900"  # regargo GAS
 ESIOS_OMIE = "10211"  # precio mayorista
 ESIOS_MARKET_ADJUSTMENT = "2108"  # ajuste mercado Indexada VS PVPC
+ESIOS_INDEXED = "0"  # precio indexado restando PVPC y el ajuste
 
 # unique ids for each series
 KEY_PVPC = "PVPC"
@@ -61,6 +62,7 @@ KEY_INJECTION = "INJECTION"
 KEY_MAG = "MAG"  # regargo GAS
 KEY_OMIE = "OMIE"  # precio mayorista
 KEY_ADJUSTMENT = "ADJUSTMENT"  # ajuste mercado
+KEY_INDEXED = "INDEXED" # precio indexada
 
 ALL_SENSORS = (KEY_PVPC, KEY_INJECTION, KEY_MAG, KEY_OMIE, KEY_ADJUSTMENT)
 SENSOR_KEY_TO_DATAID = {
@@ -68,14 +70,16 @@ SENSOR_KEY_TO_DATAID = {
     KEY_INJECTION: ESIOS_INJECTION,
     KEY_MAG: ESIOS_MAG,
     KEY_OMIE: ESIOS_OMIE,
-    KEY_ADJUSTMENT: ESIOS_MARKET_ADJUSTMENT
+    KEY_ADJUSTMENT: ESIOS_MARKET_ADJUSTMENT,
+    KEY_INDEXED: ESIOS_MARKET_ADJUSTMENT,
 }
 SENSOR_KEY_TO_NAME = {
     KEY_PVPC: "PVPC T. 2.0TD",
     KEY_INJECTION: "Precio de la energía excedentaria",
     KEY_MAG: "2.0TD Excedente o déficit ajuste liquidación",
     KEY_OMIE: "Precio medio horario final suma",
-    KEY_ADJUSTMENT: "Ajuste de mercado a plazo"
+    KEY_ADJUSTMENT: "Ajuste de mercado a plazo",
+    KEY_INDEXED: "Precio tarifa Indexada"
 }
 
 

--- a/aiopvpc/const.py
+++ b/aiopvpc/const.py
@@ -62,7 +62,7 @@ KEY_INJECTION = "INJECTION"
 KEY_MAG = "MAG"  # regargo GAS
 KEY_OMIE = "OMIE"  # precio mayorista
 KEY_ADJUSTMENT = "ADJUSTMENT"  # ajuste mercado
-KEY_INDEXED = "INDEXED" # precio indexada
+KEY_INDEXED = "INDEXED"  # precio indexada
 
 ALL_SENSORS = (KEY_PVPC, KEY_INJECTION, KEY_MAG, KEY_OMIE, KEY_ADJUSTMENT)
 SENSOR_KEY_TO_DATAID = {
@@ -79,7 +79,7 @@ SENSOR_KEY_TO_NAME = {
     KEY_MAG: "2.0TD Excedente o déficit ajuste liquidación",
     KEY_OMIE: "Precio medio horario final suma",
     KEY_ADJUSTMENT: "Ajuste de mercado a plazo",
-    KEY_INDEXED: "Precio tarifa Indexada"
+    KEY_INDEXED: "Precio tarifa Indexada",
 }
 
 

--- a/aiopvpc/const.py
+++ b/aiopvpc/const.py
@@ -53,25 +53,29 @@ ESIOS_PVPC = "1001"
 ESIOS_INJECTION = "1739"
 ESIOS_MAG = "1900"  # regargo GAS
 ESIOS_OMIE = "10211"  # precio mayorista
+ESIOS_MARKET_ADJUSTMENT = "2108"  # ajuste mercado Indexada VS PVPC
 
 # unique ids for each series
 KEY_PVPC = "PVPC"
 KEY_INJECTION = "INJECTION"
 KEY_MAG = "MAG"  # regargo GAS
 KEY_OMIE = "OMIE"  # precio mayorista
+KEY_ADJUSTMENT = "ADJUSTMENT"  # ajuste mercado
 
-ALL_SENSORS = (KEY_PVPC, KEY_INJECTION, KEY_MAG, KEY_OMIE)
+ALL_SENSORS = (KEY_PVPC, KEY_INJECTION, KEY_MAG, KEY_OMIE, KEY_ADJUSTMENT)
 SENSOR_KEY_TO_DATAID = {
     KEY_PVPC: ESIOS_PVPC,
     KEY_INJECTION: ESIOS_INJECTION,
     KEY_MAG: ESIOS_MAG,
     KEY_OMIE: ESIOS_OMIE,
+    KEY_ADJUSTMENT: ESIOS_MARKET_ADJUSTMENT
 }
 SENSOR_KEY_TO_NAME = {
     KEY_PVPC: "PVPC T. 2.0TD",
     KEY_INJECTION: "Precio de la energía excedentaria",
     KEY_MAG: "2.0TD Excedente o déficit ajuste liquidación",
     KEY_OMIE: "Precio medio horario final suma",
+    KEY_ADJUSTMENT: "Ajuste de mercado a plazo"
 }
 
 

--- a/aiopvpc/ha_helpers.py
+++ b/aiopvpc/ha_helpers.py
@@ -2,12 +2,13 @@
 
 from aiopvpc.const import (
     ALL_SENSORS,
+    KEY_ADJUSTMENT,
+    KEY_INDEXED,
     KEY_INJECTION,
     KEY_MAG,
     KEY_OMIE,
     KEY_PVPC,
-    KEY_ADJUSTMENT,
-    TARIFFS, KEY_INDEXED,
+    TARIFFS,
 )
 
 _ha_uniqueid_to_sensor_key = {

--- a/aiopvpc/ha_helpers.py
+++ b/aiopvpc/ha_helpers.py
@@ -6,6 +6,7 @@ from aiopvpc.const import (
     KEY_MAG,
     KEY_OMIE,
     KEY_PVPC,
+    KEY_ADJUSTMENT,
     TARIFFS,
 )
 
@@ -20,6 +21,8 @@ _ha_uniqueid_to_sensor_key = {
     f"{TARIFFS[1]}_{KEY_MAG}": KEY_MAG,
     f"{TARIFFS[0]}_{KEY_OMIE}": KEY_OMIE,
     f"{TARIFFS[1]}_{KEY_OMIE}": KEY_OMIE,
+    f"{TARIFFS[0]}_{KEY_ADJUSTMENT}": KEY_ADJUSTMENT,
+    f"{TARIFFS[1]}_{KEY_ADJUSTMENT}": KEY_ADJUSTMENT,
 }
 
 

--- a/aiopvpc/ha_helpers.py
+++ b/aiopvpc/ha_helpers.py
@@ -7,7 +7,7 @@ from aiopvpc.const import (
     KEY_OMIE,
     KEY_PVPC,
     KEY_ADJUSTMENT,
-    TARIFFS,
+    TARIFFS, KEY_INDEXED,
 )
 
 _ha_uniqueid_to_sensor_key = {
@@ -23,6 +23,8 @@ _ha_uniqueid_to_sensor_key = {
     f"{TARIFFS[1]}_{KEY_OMIE}": KEY_OMIE,
     f"{TARIFFS[0]}_{KEY_ADJUSTMENT}": KEY_ADJUSTMENT,
     f"{TARIFFS[1]}_{KEY_ADJUSTMENT}": KEY_ADJUSTMENT,
+    f"{TARIFFS[0]}_{KEY_INDEXED}": KEY_INDEXED,
+    f"{TARIFFS[1]}_{KEY_INDEXED}": KEY_INDEXED,
 }
 
 
@@ -41,7 +43,7 @@ def get_enabled_sensor_keys(
 
 def make_sensor_unique_id(config_entry_id: str, sensor_key: str) -> str:
     """(HA) Generate unique_id for each sensor kind and config entry."""
-    assert sensor_key in ALL_SENSORS
+    assert sensor_key in ALL_SENSORS or sensor_key == KEY_INDEXED
     if sensor_key == KEY_PVPC:
         # for old compatibility
         return config_entry_id

--- a/aiopvpc/pvpc_data.py
+++ b/aiopvpc/pvpc_data.py
@@ -277,8 +277,8 @@ class PVPCData:
             current_data.last_update = utc_now
 
         if (
-            current_data.availability[KEY_PVPC]
-            and current_data.availability[KEY_ADJUSTMENT]
+            KEY_PVPC in current_data.availability
+            and KEY_ADJUSTMENT in current_data.availability
         ):
             self._calculate_indexed(current_data)
 

--- a/aiopvpc/pvpc_data.py
+++ b/aiopvpc/pvpc_data.py
@@ -26,12 +26,14 @@ from aiopvpc.const import (
     DEFAULT_TIMEOUT,
     EsiosApiData,
     EsiosResponse,
+    KEY_ADJUSTMENT,
+    KEY_INDEXED,
     KEY_PVPC,
     REFERENCE_TZ,
     SENSOR_KEY_TO_DATAID,
     TARIFFS,
     UTC_TZ,
-    zoneinfo, KEY_INDEXED, KEY_ADJUSTMENT,
+    zoneinfo,
 )
 from aiopvpc.parser import extract_esios_data, get_daily_urls_to_download
 from aiopvpc.prices import make_price_sensor_attributes
@@ -274,7 +276,10 @@ class PVPCData:
             current_data.data_source = self._data_source
             current_data.last_update = utc_now
 
-        if current_data.availability[KEY_PVPC] and current_data.availability[KEY_ADJUSTMENT]:
+        if (
+            current_data.availability[KEY_PVPC]
+            and current_data.availability[KEY_ADJUSTMENT]
+        ):
             self._calculate_indexed(current_data)
 
         for sensor_key in current_data.sensors:
@@ -284,7 +289,9 @@ class PVPCData:
     def _calculate_indexed(self, current_data: EsiosApiData):
         pvpc = current_data.sensors[KEY_PVPC]
         adjustment = current_data.sensors[KEY_ADJUSTMENT]
-        current_data.sensors[KEY_INDEXED] = {date: pvpc[date] - adjustment[date] for date in pvpc}
+        current_data.sensors[KEY_INDEXED] = {
+            date: pvpc[date] - adjustment[date] for date in pvpc
+        }
         current_data.availability[KEY_INDEXED] = True
 
     async def _update_prices_series(

--- a/aiopvpc/pvpc_data.py
+++ b/aiopvpc/pvpc_data.py
@@ -274,7 +274,8 @@ class PVPCData:
             current_data.data_source = self._data_source
             current_data.last_update = utc_now
 
-        self._calculate_indexed(current_data)
+        if current_data.availability[KEY_PVPC] and current_data.availability[KEY_ADJUSTMENT]:
+            self._calculate_indexed(current_data)
 
         for sensor_key in current_data.sensors:
             self.process_state_and_attributes(current_data, sensor_key, now)

--- a/tests/api_examples/PRICES_ESIOS_1001_2024_03_09.json
+++ b/tests/api_examples/PRICES_ESIOS_1001_2024_03_09.json
@@ -1,1007 +1,1007 @@
 {
-    "indicator": {
-        "name": "Término de facturación de energía activa del PVPC 2.0TD",
-        "short_name": "PVPC T. 2.0TD",
-        "id": 1001,
-        "composited": false,
-        "step_type": "linear",
-        "disaggregated": true,
-        "magnitud": [
-            {
-                "name": "Precio",
-                "id": 23
-            }
-        ],
-        "tiempo": [
-            {
-                "name": "Hora",
-                "id": 4
-            }
-        ],
-        "geos": [
-            {
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            }
-        ],
-        "values_updated_at": "2024-03-08T20:46:37.000+01:00",
-        "values": [
-            {
-                "value": 44.98,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 44.98,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 44.98,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 44.98,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 44.98,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 46.14,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 46.14,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 46.14,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 46.14,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 46.14,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 46.75,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 46.75,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 46.75,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 46.75,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 46.75,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 45.72,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 45.72,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 45.72,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 45.72,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 45.72,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 45.95,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 45.95,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 45.95,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 45.95,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 45.95,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 45.89,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 45.89,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 45.89,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 45.89,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 45.89,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 45.3,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 45.3,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 45.3,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 45.3,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 45.3,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 45.04,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 45.04,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 45.04,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 45.04,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 45.04,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 42.25,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 42.25,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 42.25,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 42.25,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 42.25,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 44.92,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 44.92,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 44.92,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 44.92,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 44.92,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 44.21,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 44.21,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 44.21,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 44.21,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 44.21,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 42.83,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 42.83,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 42.83,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 42.83,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 42.83,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 42.68,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 42.68,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 42.68,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 42.68,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 42.68,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 42.14,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 42.14,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 42.14,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 42.14,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 42.14,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 42.38,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 42.38,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 42.38,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 42.38,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 42.38,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 43.04,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 43.04,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 43.04,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 43.04,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 43.04,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 43.95,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 43.95,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 43.95,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 43.95,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 43.95,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 44.72,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 44.72,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 44.72,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 44.72,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 44.72,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 44.61,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 44.61,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 44.61,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 44.61,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 44.61,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 46.43,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 46.43,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 46.43,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 46.43,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 46.43,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 46.81,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 46.81,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 46.81,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 46.81,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 46.81,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 43.97,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 43.97,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 43.97,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 43.97,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 43.97,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 44.05,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 44.05,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 44.05,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 44.05,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 44.05,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 41.94,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 41.94,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 41.94,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 41.94,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 41.94,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            }
-        ]
-    }
+  "indicator": {
+    "name": "Término de facturación de energía activa del PVPC 2.0TD",
+    "short_name": "PVPC T. 2.0TD",
+    "id": 1001,
+    "composited": false,
+    "step_type": "linear",
+    "disaggregated": true,
+    "magnitud": [
+      {
+        "name": "Precio",
+        "id": 23
+      }
+    ],
+    "tiempo": [
+      {
+        "name": "Hora",
+        "id": 4
+      }
+    ],
+    "geos": [
+      {
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      }
+    ],
+    "values_updated_at": "2024-03-08T20:46:37.000+01:00",
+    "values": [
+      {
+        "value": 44.98,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 44.98,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 44.98,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 44.98,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 44.98,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 46.14,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 46.14,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 46.14,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 46.14,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 46.14,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 46.75,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 46.75,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 46.75,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 46.75,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 46.75,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 45.72,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 45.72,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 45.72,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 45.72,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 45.72,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 45.95,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 45.95,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 45.95,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 45.95,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 45.95,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 45.89,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 45.89,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 45.89,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 45.89,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 45.89,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 45.3,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 45.3,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 45.3,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 45.3,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 45.3,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 45.04,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 45.04,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 45.04,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 45.04,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 45.04,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 42.25,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 42.25,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 42.25,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 42.25,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 42.25,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 44.92,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 44.92,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 44.92,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 44.92,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 44.92,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 44.21,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 44.21,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 44.21,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 44.21,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 44.21,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 42.83,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 42.83,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 42.83,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 42.83,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 42.83,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 42.68,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 42.68,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 42.68,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 42.68,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 42.68,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 42.14,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 42.14,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 42.14,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 42.14,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 42.14,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 42.38,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 42.38,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 42.38,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 42.38,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 42.38,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 43.04,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 43.04,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 43.04,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 43.04,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 43.04,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 43.95,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 43.95,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 43.95,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 43.95,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 43.95,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 44.72,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 44.72,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 44.72,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 44.72,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 44.72,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 44.61,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 44.61,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 44.61,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 44.61,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 44.61,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 46.43,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 46.43,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 46.43,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 46.43,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 46.43,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 46.81,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 46.81,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 46.81,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 46.81,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 46.81,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 43.97,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 43.97,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 43.97,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 43.97,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 43.97,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 44.05,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 44.05,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 44.05,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 44.05,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 44.05,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 41.94,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 41.94,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 41.94,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 41.94,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 41.94,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      }
+    ]
+  }
 }

--- a/tests/api_examples/PRICES_ESIOS_1001_2024_03_09.json
+++ b/tests/api_examples/PRICES_ESIOS_1001_2024_03_09.json
@@ -1,0 +1,1007 @@
+{
+    "indicator": {
+        "name": "Término de facturación de energía activa del PVPC 2.0TD",
+        "short_name": "PVPC T. 2.0TD",
+        "id": 1001,
+        "composited": false,
+        "step_type": "linear",
+        "disaggregated": true,
+        "magnitud": [
+            {
+                "name": "Precio",
+                "id": 23
+            }
+        ],
+        "tiempo": [
+            {
+                "name": "Hora",
+                "id": 4
+            }
+        ],
+        "geos": [
+            {
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            }
+        ],
+        "values_updated_at": "2024-03-08T20:46:37.000+01:00",
+        "values": [
+            {
+                "value": 44.98,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 44.98,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 44.98,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 44.98,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 44.98,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 46.14,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 46.14,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 46.14,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 46.14,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 46.14,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 46.75,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 46.75,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 46.75,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 46.75,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 46.75,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 45.72,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 45.72,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 45.72,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 45.72,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 45.72,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 45.95,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 45.95,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 45.95,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 45.95,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 45.95,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 45.89,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 45.89,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 45.89,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 45.89,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 45.89,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 45.3,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 45.3,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 45.3,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 45.3,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 45.3,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 45.04,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 45.04,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 45.04,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 45.04,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 45.04,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 42.25,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 42.25,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 42.25,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 42.25,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 42.25,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 44.92,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 44.92,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 44.92,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 44.92,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 44.92,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 44.21,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 44.21,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 44.21,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 44.21,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 44.21,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 42.83,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 42.83,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 42.83,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 42.83,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 42.83,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 42.68,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 42.68,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 42.68,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 42.68,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 42.68,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 42.14,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 42.14,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 42.14,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 42.14,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 42.14,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 42.38,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 42.38,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 42.38,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 42.38,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 42.38,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 43.04,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 43.04,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 43.04,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 43.04,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 43.04,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 43.95,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 43.95,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 43.95,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 43.95,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 43.95,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 44.72,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 44.72,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 44.72,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 44.72,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 44.72,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 44.61,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 44.61,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 44.61,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 44.61,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 44.61,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 46.43,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 46.43,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 46.43,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 46.43,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 46.43,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 46.81,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 46.81,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 46.81,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 46.81,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 46.81,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 43.97,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 43.97,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 43.97,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 43.97,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 43.97,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 44.05,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 44.05,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 44.05,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 44.05,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 44.05,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 41.94,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 41.94,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 41.94,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 41.94,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 41.94,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            }
+        ]
+    }
+}

--- a/tests/api_examples/PRICES_ESIOS_10211_2024_03_09.json
+++ b/tests/api_examples/PRICES_ESIOS_10211_2024_03_09.json
@@ -1,0 +1,223 @@
+{
+    "indicator": {
+        "name": "Precio medio horario final suma de componentes",
+        "short_name": "Precio medio horario final suma",
+        "id": 10211,
+        "composited": true,
+        "step_type": "linear",
+        "disaggregated": false,
+        "magnitud": [
+            {
+                "name": "Precio",
+                "id": 23
+            }
+        ],
+        "tiempo": [
+            {
+                "name": "Hora",
+                "id": 4
+            }
+        ],
+        "geos": [
+            {
+                "geo_id": 8741,
+                "geo_name": "Península"
+            }
+        ],
+        "values_updated_at": "2024-03-09T17:24:32.000+01:00",
+        "values": [
+            {
+                "value": 7.08,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 7.77,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 8.15,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 8.57,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 8.72,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 8.64,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 8.17,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 8.19,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 6.61,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 9.42,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 9.05,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 8.0,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 7.87,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 7.81,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 7.94,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 8.2,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 8.63,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 8.98,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 8.56,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 9.83,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 9.93,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 6.85,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 7.09,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 4.9,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            }
+        ]
+    }
+}

--- a/tests/api_examples/PRICES_ESIOS_10211_2024_03_09.json
+++ b/tests/api_examples/PRICES_ESIOS_10211_2024_03_09.json
@@ -1,223 +1,223 @@
 {
-    "indicator": {
-        "name": "Precio medio horario final suma de componentes",
-        "short_name": "Precio medio horario final suma",
-        "id": 10211,
-        "composited": true,
-        "step_type": "linear",
-        "disaggregated": false,
-        "magnitud": [
-            {
-                "name": "Precio",
-                "id": 23
-            }
-        ],
-        "tiempo": [
-            {
-                "name": "Hora",
-                "id": 4
-            }
-        ],
-        "geos": [
-            {
-                "geo_id": 8741,
-                "geo_name": "Península"
-            }
-        ],
-        "values_updated_at": "2024-03-09T17:24:32.000+01:00",
-        "values": [
-            {
-                "value": 7.08,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 7.77,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 8.15,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 8.57,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 8.72,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 8.64,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 8.17,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 8.19,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 6.61,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 9.42,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 9.05,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 8.0,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 7.87,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 7.81,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 7.94,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 8.2,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 8.63,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 8.98,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 8.56,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 9.83,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 9.93,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 6.85,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 7.09,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 4.9,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            }
-        ]
-    }
+  "indicator": {
+    "name": "Precio medio horario final suma de componentes",
+    "short_name": "Precio medio horario final suma",
+    "id": 10211,
+    "composited": true,
+    "step_type": "linear",
+    "disaggregated": false,
+    "magnitud": [
+      {
+        "name": "Precio",
+        "id": 23
+      }
+    ],
+    "tiempo": [
+      {
+        "name": "Hora",
+        "id": 4
+      }
+    ],
+    "geos": [
+      {
+        "geo_id": 8741,
+        "geo_name": "Península"
+      }
+    ],
+    "values_updated_at": "2024-03-09T17:24:32.000+01:00",
+    "values": [
+      {
+        "value": 7.08,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 7.77,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 8.15,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 8.57,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 8.72,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 8.64,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 8.17,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 8.19,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 6.61,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 9.42,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 9.05,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 8.0,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 7.87,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 7.81,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 7.94,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 8.2,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 8.63,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 8.98,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 8.56,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 9.83,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 9.93,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 6.85,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 7.09,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 4.9,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      }
+    ]
+  }
 }

--- a/tests/api_examples/PRICES_ESIOS_1739_2024_03_09.json
+++ b/tests/api_examples/PRICES_ESIOS_1739_2024_03_09.json
@@ -1,223 +1,223 @@
 {
-    "indicator": {
-        "name": "Precio de la energía excedentaria del autoconsumo para el mecanismo de compensación simplificada (PVPC)",
-        "short_name": "Precio de la energía excedentaria",
-        "id": 1739,
-        "composited": false,
-        "step_type": "linear",
-        "disaggregated": false,
-        "magnitud": [
-            {
-                "name": "Precio",
-                "id": 23
-            }
-        ],
-        "tiempo": [
-            {
-                "name": "Hora",
-                "id": 4
-            }
-        ],
-        "geos": [
-            {
-                "geo_id": 3,
-                "geo_name": "España"
-            }
-        ],
-        "values_updated_at": "2024-03-08T20:46:37.000+01:00",
-        "values": [
-            {
-                "value": -1.45,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.57,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.74,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.96,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.98,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.82,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.7,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.56,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.49,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.28,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.0,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.32,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.42,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.65,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.7,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.89,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.88,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.69,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.23,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": 1.59,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": 2.09,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": 1.79,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": 1.46,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            },
-            {
-                "value": -1.24,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 3,
-                "geo_name": "España"
-            }
-        ]
-    }
+  "indicator": {
+    "name": "Precio de la energía excedentaria del autoconsumo para el mecanismo de compensación simplificada (PVPC)",
+    "short_name": "Precio de la energía excedentaria",
+    "id": 1739,
+    "composited": false,
+    "step_type": "linear",
+    "disaggregated": false,
+    "magnitud": [
+      {
+        "name": "Precio",
+        "id": 23
+      }
+    ],
+    "tiempo": [
+      {
+        "name": "Hora",
+        "id": 4
+      }
+    ],
+    "geos": [
+      {
+        "geo_id": 3,
+        "geo_name": "España"
+      }
+    ],
+    "values_updated_at": "2024-03-08T20:46:37.000+01:00",
+    "values": [
+      {
+        "value": -1.45,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.57,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.74,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.96,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.98,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.82,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.7,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.56,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.49,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.28,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.0,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.32,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.42,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.65,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.7,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.89,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.88,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.69,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.23,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": 1.59,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": 2.09,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": 1.79,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": 1.46,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      },
+      {
+        "value": -1.24,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 3,
+        "geo_name": "España"
+      }
+    ]
+  }
 }

--- a/tests/api_examples/PRICES_ESIOS_1739_2024_03_09.json
+++ b/tests/api_examples/PRICES_ESIOS_1739_2024_03_09.json
@@ -1,0 +1,223 @@
+{
+    "indicator": {
+        "name": "Precio de la energía excedentaria del autoconsumo para el mecanismo de compensación simplificada (PVPC)",
+        "short_name": "Precio de la energía excedentaria",
+        "id": 1739,
+        "composited": false,
+        "step_type": "linear",
+        "disaggregated": false,
+        "magnitud": [
+            {
+                "name": "Precio",
+                "id": 23
+            }
+        ],
+        "tiempo": [
+            {
+                "name": "Hora",
+                "id": 4
+            }
+        ],
+        "geos": [
+            {
+                "geo_id": 3,
+                "geo_name": "España"
+            }
+        ],
+        "values_updated_at": "2024-03-08T20:46:37.000+01:00",
+        "values": [
+            {
+                "value": -1.45,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.57,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.74,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.96,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.98,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.82,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.7,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.56,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.49,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.28,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.0,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.32,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.42,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.65,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.7,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.89,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.88,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.69,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.23,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": 1.59,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": 2.09,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": 1.79,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": 1.46,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            },
+            {
+                "value": -1.24,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 3,
+                "geo_name": "España"
+            }
+        ]
+    }
+}

--- a/tests/api_examples/PRICES_ESIOS_1900_2024_03_09.json
+++ b/tests/api_examples/PRICES_ESIOS_1900_2024_03_09.json
@@ -1,0 +1,1007 @@
+{
+    "indicator": {
+        "name": "Desglose peaje por defecto 2.0TD excedente o déficit de la liquidación del mecanismo de ajuste de costes de producción",
+        "short_name": "2.0TD Excedente o déficit ajuste liquidación",
+        "id": 1900,
+        "composited": false,
+        "step_type": "linear",
+        "disaggregated": true,
+        "magnitud": [
+            {
+                "name": "Precio",
+                "id": 23
+            }
+        ],
+        "tiempo": [
+            {
+                "name": "Hora",
+                "id": 4
+            }
+        ],
+        "geos": [
+            {
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            }
+        ],
+        "values_updated_at": "2024-03-08T20:46:37.000+01:00",
+        "values": [
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 5.0,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 5.0,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 0.0,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            }
+        ]
+    }
+}

--- a/tests/api_examples/PRICES_ESIOS_1900_2024_03_09.json
+++ b/tests/api_examples/PRICES_ESIOS_1900_2024_03_09.json
@@ -1,1007 +1,1007 @@
 {
-    "indicator": {
-        "name": "Desglose peaje por defecto 2.0TD excedente o déficit de la liquidación del mecanismo de ajuste de costes de producción",
-        "short_name": "2.0TD Excedente o déficit ajuste liquidación",
-        "id": 1900,
-        "composited": false,
-        "step_type": "linear",
-        "disaggregated": true,
-        "magnitud": [
-            {
-                "name": "Precio",
-                "id": 23
-            }
-        ],
-        "tiempo": [
-            {
-                "name": "Hora",
-                "id": 4
-            }
-        ],
-        "geos": [
-            {
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            }
-        ],
-        "values_updated_at": "2024-03-08T20:46:37.000+01:00",
-        "values": [
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 5.0,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 5.0,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 0.0,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            }
-        ]
-    }
+  "indicator": {
+    "name": "Desglose peaje por defecto 2.0TD excedente o déficit de la liquidación del mecanismo de ajuste de costes de producción",
+    "short_name": "2.0TD Excedente o déficit ajuste liquidación",
+    "id": 1900,
+    "composited": false,
+    "step_type": "linear",
+    "disaggregated": true,
+    "magnitud": [
+      {
+        "name": "Precio",
+        "id": 23
+      }
+    ],
+    "tiempo": [
+      {
+        "name": "Hora",
+        "id": 4
+      }
+    ],
+    "geos": [
+      {
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      }
+    ],
+    "values_updated_at": "2024-03-08T20:46:37.000+01:00",
+    "values": [
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 5.0,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 5.0,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 0.0,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      }
+    ]
+  }
 }

--- a/tests/api_examples/PRICES_ESIOS_2108_2024_03_09.json
+++ b/tests/api_examples/PRICES_ESIOS_2108_2024_03_09.json
@@ -1,1007 +1,1007 @@
 {
-    "indicator": {
-        "name": "Término de ajuste de mercados a plazo",
-        "short_name": "Término de ajuste de mercados a plazo",
-        "id": 2108,
-        "composited": false,
-        "step_type": "linear",
-        "disaggregated": true,
-        "magnitud": [
-            {
-                "name": "Precio",
-                "id": 23
-            }
-        ],
-        "tiempo": [
-            {
-                "name": "Hora",
-                "id": 4
-            }
-        ],
-        "geos": [
-            {
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            }
-        ],
-        "values_updated_at": "2024-03-08T20:46:37.000+01:00",
-        "values": [
-            {
-                "value": 23.81,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 23.81,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 23.81,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 23.81,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 23.81,
-                "datetime": "2024-03-09T00:00:00.000+01:00",
-                "datetime_utc": "2024-03-08T23:00:00Z",
-                "tz_time": "2024-03-08T23:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 23.95,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 23.95,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 23.95,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 23.95,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 23.95,
-                "datetime": "2024-03-09T01:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T00:00:00Z",
-                "tz_time": "2024-03-09T00:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 24.07,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 24.07,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 24.07,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 24.07,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 24.07,
-                "datetime": "2024-03-09T02:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T01:00:00Z",
-                "tz_time": "2024-03-09T01:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 24.11,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 24.11,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 24.11,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 24.11,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 24.11,
-                "datetime": "2024-03-09T03:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T02:00:00Z",
-                "tz_time": "2024-03-09T02:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 24.15,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 24.15,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 24.15,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 24.15,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 24.15,
-                "datetime": "2024-03-09T04:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T03:00:00Z",
-                "tz_time": "2024-03-09T03:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 24.11,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 24.11,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 24.11,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 24.11,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 24.11,
-                "datetime": "2024-03-09T05:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T04:00:00Z",
-                "tz_time": "2024-03-09T04:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 24.03,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 24.03,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 24.03,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 24.03,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 24.03,
-                "datetime": "2024-03-09T06:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T05:00:00Z",
-                "tz_time": "2024-03-09T05:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 23.81,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 23.81,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 23.81,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 23.81,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 23.81,
-                "datetime": "2024-03-09T07:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T06:00:00Z",
-                "tz_time": "2024-03-09T06:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 23.31,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 23.31,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 23.31,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 23.31,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 23.31,
-                "datetime": "2024-03-09T08:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T07:00:00Z",
-                "tz_time": "2024-03-09T07:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 22.86,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 22.86,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 22.86,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 22.86,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 22.86,
-                "datetime": "2024-03-09T09:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T08:00:00Z",
-                "tz_time": "2024-03-09T08:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 22.73,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 22.73,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 22.73,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 22.73,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 22.73,
-                "datetime": "2024-03-09T10:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T09:00:00Z",
-                "tz_time": "2024-03-09T09:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 22.67,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 22.67,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 22.67,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 22.67,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 22.67,
-                "datetime": "2024-03-09T11:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T10:00:00Z",
-                "tz_time": "2024-03-09T10:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 22.67,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 22.67,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 22.67,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 22.67,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 22.67,
-                "datetime": "2024-03-09T12:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T11:00:00Z",
-                "tz_time": "2024-03-09T11:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 22.55,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 22.55,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 22.55,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 22.55,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 22.55,
-                "datetime": "2024-03-09T13:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T12:00:00Z",
-                "tz_time": "2024-03-09T12:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 22.61,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 22.61,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 22.61,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 22.61,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 22.61,
-                "datetime": "2024-03-09T14:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T13:00:00Z",
-                "tz_time": "2024-03-09T13:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 22.9,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 22.9,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 22.9,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 22.9,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 22.9,
-                "datetime": "2024-03-09T15:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T14:00:00Z",
-                "tz_time": "2024-03-09T14:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 23.11,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 23.11,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 23.11,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 23.11,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 23.11,
-                "datetime": "2024-03-09T16:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T15:00:00Z",
-                "tz_time": "2024-03-09T15:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 23.19,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 23.19,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 23.19,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 23.19,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 23.19,
-                "datetime": "2024-03-09T17:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T16:00:00Z",
-                "tz_time": "2024-03-09T16:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 23.43,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 23.43,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 23.43,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 23.43,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 23.43,
-                "datetime": "2024-03-09T18:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T17:00:00Z",
-                "tz_time": "2024-03-09T17:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 23.64,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 23.64,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 23.64,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 23.64,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 23.64,
-                "datetime": "2024-03-09T19:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T18:00:00Z",
-                "tz_time": "2024-03-09T18:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 23.66,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 23.66,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 23.66,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 23.66,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 23.66,
-                "datetime": "2024-03-09T20:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T19:00:00Z",
-                "tz_time": "2024-03-09T19:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 23.62,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 23.62,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 23.62,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 23.62,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 23.62,
-                "datetime": "2024-03-09T21:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T20:00:00Z",
-                "tz_time": "2024-03-09T20:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 23.66,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 23.66,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 23.66,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 23.66,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 23.66,
-                "datetime": "2024-03-09T22:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T21:00:00Z",
-                "tz_time": "2024-03-09T21:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            },
-            {
-                "value": 23.78,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 8741,
-                "geo_name": "Península"
-            },
-            {
-                "value": 23.78,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 8742,
-                "geo_name": "Canarias"
-            },
-            {
-                "value": 23.78,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 8743,
-                "geo_name": "Baleares"
-            },
-            {
-                "value": 23.78,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 8744,
-                "geo_name": "Ceuta"
-            },
-            {
-                "value": 23.78,
-                "datetime": "2024-03-09T23:00:00.000+01:00",
-                "datetime_utc": "2024-03-09T22:00:00Z",
-                "tz_time": "2024-03-09T22:00:00.000Z",
-                "geo_id": 8745,
-                "geo_name": "Melilla"
-            }
-        ]
-    }
+  "indicator": {
+    "name": "Término de ajuste de mercados a plazo",
+    "short_name": "Término de ajuste de mercados a plazo",
+    "id": 2108,
+    "composited": false,
+    "step_type": "linear",
+    "disaggregated": true,
+    "magnitud": [
+      {
+        "name": "Precio",
+        "id": 23
+      }
+    ],
+    "tiempo": [
+      {
+        "name": "Hora",
+        "id": 4
+      }
+    ],
+    "geos": [
+      {
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      }
+    ],
+    "values_updated_at": "2024-03-08T20:46:37.000+01:00",
+    "values": [
+      {
+        "value": 23.81,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 23.81,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 23.81,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 23.81,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 23.81,
+        "datetime": "2024-03-09T00:00:00.000+01:00",
+        "datetime_utc": "2024-03-08T23:00:00Z",
+        "tz_time": "2024-03-08T23:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 23.95,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 23.95,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 23.95,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 23.95,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 23.95,
+        "datetime": "2024-03-09T01:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T00:00:00Z",
+        "tz_time": "2024-03-09T00:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 24.07,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 24.07,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 24.07,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 24.07,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 24.07,
+        "datetime": "2024-03-09T02:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T01:00:00Z",
+        "tz_time": "2024-03-09T01:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 24.11,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 24.11,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 24.11,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 24.11,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 24.11,
+        "datetime": "2024-03-09T03:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T02:00:00Z",
+        "tz_time": "2024-03-09T02:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 24.15,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 24.15,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 24.15,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 24.15,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 24.15,
+        "datetime": "2024-03-09T04:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T03:00:00Z",
+        "tz_time": "2024-03-09T03:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 24.11,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 24.11,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 24.11,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 24.11,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 24.11,
+        "datetime": "2024-03-09T05:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T04:00:00Z",
+        "tz_time": "2024-03-09T04:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 24.03,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 24.03,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 24.03,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 24.03,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 24.03,
+        "datetime": "2024-03-09T06:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T05:00:00Z",
+        "tz_time": "2024-03-09T05:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 23.81,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 23.81,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 23.81,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 23.81,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 23.81,
+        "datetime": "2024-03-09T07:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T06:00:00Z",
+        "tz_time": "2024-03-09T06:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 23.31,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 23.31,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 23.31,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 23.31,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 23.31,
+        "datetime": "2024-03-09T08:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T07:00:00Z",
+        "tz_time": "2024-03-09T07:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 22.86,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 22.86,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 22.86,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 22.86,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 22.86,
+        "datetime": "2024-03-09T09:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T08:00:00Z",
+        "tz_time": "2024-03-09T08:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 22.73,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 22.73,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 22.73,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 22.73,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 22.73,
+        "datetime": "2024-03-09T10:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T09:00:00Z",
+        "tz_time": "2024-03-09T09:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 22.67,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 22.67,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 22.67,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 22.67,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 22.67,
+        "datetime": "2024-03-09T11:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T10:00:00Z",
+        "tz_time": "2024-03-09T10:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 22.67,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 22.67,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 22.67,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 22.67,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 22.67,
+        "datetime": "2024-03-09T12:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T11:00:00Z",
+        "tz_time": "2024-03-09T11:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 22.55,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 22.55,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 22.55,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 22.55,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 22.55,
+        "datetime": "2024-03-09T13:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T12:00:00Z",
+        "tz_time": "2024-03-09T12:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 22.61,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 22.61,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 22.61,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 22.61,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 22.61,
+        "datetime": "2024-03-09T14:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T13:00:00Z",
+        "tz_time": "2024-03-09T13:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 22.9,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 22.9,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 22.9,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 22.9,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 22.9,
+        "datetime": "2024-03-09T15:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T14:00:00Z",
+        "tz_time": "2024-03-09T14:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 23.11,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 23.11,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 23.11,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 23.11,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 23.11,
+        "datetime": "2024-03-09T16:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T15:00:00Z",
+        "tz_time": "2024-03-09T15:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 23.19,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 23.19,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 23.19,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 23.19,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 23.19,
+        "datetime": "2024-03-09T17:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T16:00:00Z",
+        "tz_time": "2024-03-09T16:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 23.43,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 23.43,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 23.43,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 23.43,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 23.43,
+        "datetime": "2024-03-09T18:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T17:00:00Z",
+        "tz_time": "2024-03-09T17:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 23.64,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 23.64,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 23.64,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 23.64,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 23.64,
+        "datetime": "2024-03-09T19:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T18:00:00Z",
+        "tz_time": "2024-03-09T18:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 23.66,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 23.66,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 23.66,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 23.66,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 23.66,
+        "datetime": "2024-03-09T20:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T19:00:00Z",
+        "tz_time": "2024-03-09T19:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 23.62,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 23.62,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 23.62,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 23.62,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 23.62,
+        "datetime": "2024-03-09T21:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T20:00:00Z",
+        "tz_time": "2024-03-09T20:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 23.66,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 23.66,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 23.66,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 23.66,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 23.66,
+        "datetime": "2024-03-09T22:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T21:00:00Z",
+        "tz_time": "2024-03-09T21:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      },
+      {
+        "value": 23.78,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 8741,
+        "geo_name": "Península"
+      },
+      {
+        "value": 23.78,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 8742,
+        "geo_name": "Canarias"
+      },
+      {
+        "value": 23.78,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 8743,
+        "geo_name": "Baleares"
+      },
+      {
+        "value": 23.78,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 8744,
+        "geo_name": "Ceuta"
+      },
+      {
+        "value": 23.78,
+        "datetime": "2024-03-09T23:00:00.000+01:00",
+        "datetime_utc": "2024-03-09T22:00:00Z",
+        "tz_time": "2024-03-09T22:00:00.000Z",
+        "geo_id": 8745,
+        "geo_name": "Melilla"
+      }
+    ]
+  }
 }

--- a/tests/api_examples/PRICES_ESIOS_2108_2024_03_09.json
+++ b/tests/api_examples/PRICES_ESIOS_2108_2024_03_09.json
@@ -1,0 +1,1007 @@
+{
+    "indicator": {
+        "name": "Término de ajuste de mercados a plazo",
+        "short_name": "Término de ajuste de mercados a plazo",
+        "id": 2108,
+        "composited": false,
+        "step_type": "linear",
+        "disaggregated": true,
+        "magnitud": [
+            {
+                "name": "Precio",
+                "id": 23
+            }
+        ],
+        "tiempo": [
+            {
+                "name": "Hora",
+                "id": 4
+            }
+        ],
+        "geos": [
+            {
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            }
+        ],
+        "values_updated_at": "2024-03-08T20:46:37.000+01:00",
+        "values": [
+            {
+                "value": 23.81,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 23.81,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 23.81,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 23.81,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 23.81,
+                "datetime": "2024-03-09T00:00:00.000+01:00",
+                "datetime_utc": "2024-03-08T23:00:00Z",
+                "tz_time": "2024-03-08T23:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 23.95,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 23.95,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 23.95,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 23.95,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 23.95,
+                "datetime": "2024-03-09T01:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T00:00:00Z",
+                "tz_time": "2024-03-09T00:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 24.07,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 24.07,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 24.07,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 24.07,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 24.07,
+                "datetime": "2024-03-09T02:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T01:00:00Z",
+                "tz_time": "2024-03-09T01:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 24.11,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 24.11,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 24.11,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 24.11,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 24.11,
+                "datetime": "2024-03-09T03:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T02:00:00Z",
+                "tz_time": "2024-03-09T02:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 24.15,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 24.15,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 24.15,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 24.15,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 24.15,
+                "datetime": "2024-03-09T04:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T03:00:00Z",
+                "tz_time": "2024-03-09T03:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 24.11,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 24.11,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 24.11,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 24.11,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 24.11,
+                "datetime": "2024-03-09T05:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T04:00:00Z",
+                "tz_time": "2024-03-09T04:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 24.03,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 24.03,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 24.03,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 24.03,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 24.03,
+                "datetime": "2024-03-09T06:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T05:00:00Z",
+                "tz_time": "2024-03-09T05:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 23.81,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 23.81,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 23.81,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 23.81,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 23.81,
+                "datetime": "2024-03-09T07:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T06:00:00Z",
+                "tz_time": "2024-03-09T06:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 23.31,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 23.31,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 23.31,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 23.31,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 23.31,
+                "datetime": "2024-03-09T08:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T07:00:00Z",
+                "tz_time": "2024-03-09T07:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 22.86,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 22.86,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 22.86,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 22.86,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 22.86,
+                "datetime": "2024-03-09T09:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T08:00:00Z",
+                "tz_time": "2024-03-09T08:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 22.73,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 22.73,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 22.73,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 22.73,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 22.73,
+                "datetime": "2024-03-09T10:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T09:00:00Z",
+                "tz_time": "2024-03-09T09:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 22.67,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 22.67,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 22.67,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 22.67,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 22.67,
+                "datetime": "2024-03-09T11:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T10:00:00Z",
+                "tz_time": "2024-03-09T10:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 22.67,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 22.67,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 22.67,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 22.67,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 22.67,
+                "datetime": "2024-03-09T12:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T11:00:00Z",
+                "tz_time": "2024-03-09T11:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 22.55,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 22.55,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 22.55,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 22.55,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 22.55,
+                "datetime": "2024-03-09T13:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T12:00:00Z",
+                "tz_time": "2024-03-09T12:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 22.61,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 22.61,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 22.61,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 22.61,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 22.61,
+                "datetime": "2024-03-09T14:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T13:00:00Z",
+                "tz_time": "2024-03-09T13:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 22.9,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 22.9,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 22.9,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 22.9,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 22.9,
+                "datetime": "2024-03-09T15:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T14:00:00Z",
+                "tz_time": "2024-03-09T14:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 23.11,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 23.11,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 23.11,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 23.11,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 23.11,
+                "datetime": "2024-03-09T16:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T15:00:00Z",
+                "tz_time": "2024-03-09T15:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 23.19,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 23.19,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 23.19,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 23.19,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 23.19,
+                "datetime": "2024-03-09T17:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T16:00:00Z",
+                "tz_time": "2024-03-09T16:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 23.43,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 23.43,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 23.43,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 23.43,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 23.43,
+                "datetime": "2024-03-09T18:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T17:00:00Z",
+                "tz_time": "2024-03-09T17:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 23.64,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 23.64,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 23.64,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 23.64,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 23.64,
+                "datetime": "2024-03-09T19:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T18:00:00Z",
+                "tz_time": "2024-03-09T18:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 23.66,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 23.66,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 23.66,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 23.66,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 23.66,
+                "datetime": "2024-03-09T20:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T19:00:00Z",
+                "tz_time": "2024-03-09T19:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 23.62,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 23.62,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 23.62,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 23.62,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 23.62,
+                "datetime": "2024-03-09T21:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T20:00:00Z",
+                "tz_time": "2024-03-09T20:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 23.66,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 23.66,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 23.66,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 23.66,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 23.66,
+                "datetime": "2024-03-09T22:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T21:00:00Z",
+                "tz_time": "2024-03-09T21:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            },
+            {
+                "value": 23.78,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 8741,
+                "geo_name": "Península"
+            },
+            {
+                "value": 23.78,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 8742,
+                "geo_name": "Canarias"
+            },
+            {
+                "value": 23.78,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 8743,
+                "geo_name": "Baleares"
+            },
+            {
+                "value": 23.78,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 8744,
+                "geo_name": "Ceuta"
+            },
+            {
+                "value": 23.78,
+                "datetime": "2024-03-09T23:00:00.000+01:00",
+                "datetime_utc": "2024-03-09T22:00:00Z",
+                "tz_time": "2024-03-09T22:00:00.000Z",
+                "geo_id": 8745,
+                "geo_name": "Melilla"
+            }
+        ]
+    }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import pathlib
 import zoneinfo
 from datetime import date, datetime, timedelta
 
-from aiopvpc.const import ESIOS_INJECTION, ESIOS_MAG, ESIOS_OMIE, ESIOS_PVPC, KEY_PVPC
+from aiopvpc.const import ESIOS_INJECTION, ESIOS_MAG, ESIOS_OMIE, ESIOS_PVPC, KEY_PVPC, ESIOS_MARKET_ADJUSTMENT
 from aiopvpc.pvpc_data import EsiosApiData, PVPCData
 
 TEST_EXAMPLES_PATH = pathlib.Path(__file__).parent / "api_examples"
@@ -22,13 +22,18 @@ _FIXTURE_ESIOS_PVPC_2021_10_30 = "PRICES_ESIOS_1001_2021_10_30.json"
 _FIXTURE_ESIOS_PVPC_2021_10_31 = "PRICES_ESIOS_1001_2021_10_31.json"
 _FIXTURE_ESIOS_PVPC_2021_06_01 = "PRICES_ESIOS_1001_2021_06_01.json"
 _FIXTURE_ESIOS_PVPC_2023_01_06 = "PRICES_ESIOS_1001_2023_01_06.json"
+_FIXTURE_ESIOS_PVPC_2024_03_09 = "PRICES_ESIOS_1001_2024_03_09.json"
 _FIXTURE_ESIOS_INJECTION_2021_10_30 = "PRICES_ESIOS_1739_2021_10_30.json"
 _FIXTURE_ESIOS_INJECTION_2021_10_31 = "PRICES_ESIOS_1739_2021_10_31.json"
 _FIXTURE_ESIOS_INJECTION_2023_01_06 = "PRICES_ESIOS_1739_2023_01_06.json"
+_FIXTURE_ESIOS_INJECTION_2024_03_09 = "PRICES_ESIOS_1739_2024_03_09.json"
 _FIXTURE_ESIOS_OMIE_2021_10_30 = "PRICES_ESIOS_10211_2021_10_30.json"
 _FIXTURE_ESIOS_OMIE_2021_10_31 = "PRICES_ESIOS_10211_2021_10_31.json"
 _FIXTURE_ESIOS_OMIE_2023_01_06 = "PRICES_ESIOS_10211_2023_01_06.json"
+_FIXTURE_ESIOS_OMIE_2024_03_09 = "PRICES_ESIOS_10211_2024_03_09.json"
 _FIXTURE_ESIOS_MAG_2023_01_06 = "PRICES_ESIOS_1900_2023_01_06.json"
+_FIXTURE_ESIOS_MAG_2024_03_09 = "PRICES_ESIOS_1900_2024_03_09.json"
+_FIXTURE_ESIOS_ADJUSTMENT_2024_03_09 = "PRICES_ESIOS_2108_2024_03_09.json"
 
 _DEFAULT_EMPTY_VALUE = {"message": "No values for specified archive"}
 _DEFAULT_UNAUTH_MSG = "HTTP Token: Access denied (TEST)."
@@ -72,20 +77,27 @@ class MockAsyncSession:
                 date(2021, 10, 31): load_fixture(_FIXTURE_ESIOS_PVPC_2021_10_31),
                 date(2021, 6, 1): load_fixture(_FIXTURE_ESIOS_PVPC_2021_06_01),
                 date(2023, 1, 6): load_fixture(_FIXTURE_ESIOS_PVPC_2023_01_06),
+                date(2024, 3, 9): load_fixture(_FIXTURE_ESIOS_PVPC_2024_03_09),
             },
             ESIOS_INJECTION: {
                 date(2021, 10, 30): load_fixture(_FIXTURE_ESIOS_INJECTION_2021_10_30),
                 date(2021, 10, 31): load_fixture(_FIXTURE_ESIOS_INJECTION_2021_10_31),
                 date(2023, 1, 6): load_fixture(_FIXTURE_ESIOS_INJECTION_2023_01_06),
+                date(2024, 3, 9): load_fixture(_FIXTURE_ESIOS_INJECTION_2024_03_09),
             },
             ESIOS_MAG: {
                 date(2023, 1, 6): load_fixture(_FIXTURE_ESIOS_MAG_2023_01_06),
+                date(2024, 3, 9): load_fixture(_FIXTURE_ESIOS_MAG_2024_03_09),
             },
             ESIOS_OMIE: {
                 date(2021, 10, 30): load_fixture(_FIXTURE_ESIOS_OMIE_2021_10_30),
                 date(2021, 10, 31): load_fixture(_FIXTURE_ESIOS_OMIE_2021_10_31),
                 date(2023, 1, 6): load_fixture(_FIXTURE_ESIOS_OMIE_2023_01_06),
+                date(2024, 3, 9): load_fixture(_FIXTURE_ESIOS_OMIE_2024_03_09),
             },
+            ESIOS_MARKET_ADJUSTMENT: {
+                date(2024, 3, 9): load_fixture(_FIXTURE_ESIOS_ADJUSTMENT_2024_03_09)
+            }
         }
 
     async def json(self, *_args, **_kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,14 @@ import pathlib
 import zoneinfo
 from datetime import date, datetime, timedelta
 
-from aiopvpc.const import ESIOS_INJECTION, ESIOS_MAG, ESIOS_OMIE, ESIOS_PVPC, KEY_PVPC, ESIOS_MARKET_ADJUSTMENT
+from aiopvpc.const import (
+    ESIOS_INJECTION,
+    ESIOS_MAG,
+    ESIOS_MARKET_ADJUSTMENT,
+    ESIOS_OMIE,
+    ESIOS_PVPC,
+    KEY_PVPC,
+)
 from aiopvpc.pvpc_data import EsiosApiData, PVPCData
 
 TEST_EXAMPLES_PATH = pathlib.Path(__file__).parent / "api_examples"
@@ -97,7 +104,7 @@ class MockAsyncSession:
             },
             ESIOS_MARKET_ADJUSTMENT: {
                 date(2024, 3, 9): load_fixture(_FIXTURE_ESIOS_ADJUSTMENT_2024_03_09)
-            }
+            },
         }
 
     async def json(self, *_args, **_kwargs):

--- a/tests/test_ha_helpers.py
+++ b/tests/test_ha_helpers.py
@@ -9,12 +9,13 @@ import pytest
 
 from aiopvpc.const import (
     ALL_SENSORS,
+    KEY_ADJUSTMENT,
     KEY_INJECTION,
     KEY_MAG,
     KEY_OMIE,
     KEY_PVPC,
     TARIFFS,
-    UTC_TZ, KEY_ADJUSTMENT,
+    UTC_TZ,
 )
 from aiopvpc.ha_helpers import get_enabled_sensor_keys, make_sensor_unique_id
 from aiopvpc.pvpc_data import BadApiTokenAuthError, PVPCData

--- a/tests/test_ha_helpers.py
+++ b/tests/test_ha_helpers.py
@@ -14,7 +14,7 @@ from aiopvpc.const import (
     KEY_OMIE,
     KEY_PVPC,
     TARIFFS,
-    UTC_TZ,
+    UTC_TZ, KEY_ADJUSTMENT,
 )
 from aiopvpc.ha_helpers import get_enabled_sensor_keys, make_sensor_unique_id
 from aiopvpc.pvpc_data import BadApiTokenAuthError, PVPCData
@@ -48,10 +48,10 @@ def test_sensor_unique_ids():
 
 @pytest.mark.asyncio
 async def test_disable_sensors():
-    start = datetime(2023, 1, 6, 19, tzinfo=UTC_TZ)
+    start = datetime(2024, 3, 9, 19, tzinfo=UTC_TZ)
     mock_session = MockAsyncSession()
     sensor_keys = ALL_SENSORS
-    assert len(sensor_keys) == 4
+    assert len(sensor_keys) == 5
     pvpc_data = PVPCData(
         session=mock_session,
         tariff="2.0TD",
@@ -62,32 +62,33 @@ async def test_disable_sensors():
 
     api_data = None
     start, api_data = await run_h_step(mock_session, pvpc_data, api_data, start)
-    assert mock_session.call_count == 8
+    assert mock_session.call_count == 10
     check_num_datapoints(api_data, sensor_keys, 24)
 
     pvpc_data.update_active_sensors(KEY_PVPC, enabled=False)
     pvpc_data.update_active_sensors(KEY_OMIE, enabled=False)
     pvpc_data.update_active_sensors(KEY_MAG, enabled=False)
     pvpc_data.update_active_sensors(KEY_MAG, enabled=False)
+    pvpc_data.update_active_sensors(KEY_ADJUSTMENT, enabled=False)
 
     start, api_data = await run_h_step(mock_session, pvpc_data, api_data, start)
-    assert mock_session.call_count == 9
+    assert mock_session.call_count == 11
     check_num_datapoints(api_data, sensor_keys, 24)
     logging.error(api_data.sensors.keys())
 
     pvpc_data.update_active_sensors(KEY_INJECTION, enabled=False)
     start, api_data = await run_h_step(mock_session, pvpc_data, api_data, start)
-    assert mock_session.call_count == 9
+    assert mock_session.call_count == 11
     check_num_datapoints(api_data, sensor_keys, 24)
 
     start, api_data = await run_h_step(mock_session, pvpc_data, api_data, start)
-    assert mock_session.call_count == 9
+    assert mock_session.call_count == 11
     check_num_datapoints(api_data, sensor_keys, 24)
 
     start, api_data = await run_h_step(
         mock_session, pvpc_data, api_data, start, should_fail=True
     )
-    assert mock_session.call_count == 9
+    assert mock_session.call_count == 11
     # check_num_datapoints(api_data, sensor_keys, 0)
 
     pvpc_data.update_active_sensors(KEY_INJECTION, enabled=True)
@@ -95,14 +96,14 @@ async def test_disable_sensors():
     start, api_data = await run_h_step(
         mock_session, pvpc_data, api_data, start, should_fail=True
     )
-    assert mock_session.call_count == 11
+    assert mock_session.call_count == 13
 
     pvpc_data.update_active_sensors(KEY_INJECTION, enabled=True)
     pvpc_data.update_active_sensors(KEY_PVPC, enabled=True)
     pvpc_data.update_active_sensors(KEY_MAG, enabled=True)
     pvpc_data.update_active_sensors(KEY_OMIE, enabled=True)
     await run_h_step(mock_session, pvpc_data, api_data, start, should_fail=True)
-    assert mock_session.call_count == 15
+    assert mock_session.call_count == 17
 
 
 @pytest.mark.asyncio

--- a/tests/test_pvpc.py
+++ b/tests/test_pvpc.py
@@ -151,7 +151,7 @@ async def test_reduced_api_download_rate_dst_change(local_tz, data_source, senso
 @pytest.mark.asyncio
 async def test_reduced_api_download_rate(local_tz, data_source, sensor_keys):
     """Test time evolution and number of API calls."""
-    start = datetime(2023, 1, 6, 2, tzinfo=UTC_TZ)
+    start = datetime(2024, 3, 9, 2, tzinfo=UTC_TZ)
     mock_session = MockAsyncSession()
     pvpc_data = PVPCData(
         session=mock_session,
@@ -171,13 +171,13 @@ async def test_reduced_api_download_rate(local_tz, data_source, sensor_keys):
         check_num_datapoints(api_data, sensor_keys, 24)
 
     # first call for next-day prices
-    assert start == datetime(2023, 1, 6, 19, tzinfo=UTC_TZ)
+    assert start == datetime(2024, 3, 9, 19, tzinfo=UTC_TZ)
     start, api_data = await run_h_step(mock_session, pvpc_data, api_data, start)
     assert mock_session.call_count == 2 * len(sensor_keys)
     check_num_datapoints(api_data, sensor_keys, 24)
 
     call_count = mock_session.call_count
-    while start.astimezone(local_tz) <= datetime(2023, 1, 6, 23, tzinfo=local_tz):
+    while start.astimezone(local_tz) <= datetime(2024, 3, 9, 23, tzinfo=local_tz):
         start, api_data = await run_h_step(mock_session, pvpc_data, api_data, start)
         call_count += len(sensor_keys)
         assert mock_session.call_count == call_count

--- a/tests/test_pvpc_parsing.py
+++ b/tests/test_pvpc_parsing.py
@@ -8,13 +8,13 @@ import pytest
 from aiopvpc.const import (
     ALL_SENSORS,
     DataSource,
+    KEY_ADJUSTMENT,
     KEY_INJECTION,
     KEY_MAG,
     KEY_OMIE,
     KEY_PVPC,
     REFERENCE_TZ,
     SENSOR_KEY_TO_DATAID,
-    KEY_ADJUSTMENT,
 )
 from aiopvpc.pvpc_data import PVPCData
 from tests.conftest import MockAsyncSession, TZ_TEST

--- a/tests/test_pvpc_parsing.py
+++ b/tests/test_pvpc_parsing.py
@@ -14,6 +14,7 @@ from aiopvpc.const import (
     KEY_PVPC,
     REFERENCE_TZ,
     SENSOR_KEY_TO_DATAID,
+    KEY_ADJUSTMENT,
 )
 from aiopvpc.pvpc_data import PVPCData
 from tests.conftest import MockAsyncSession, TZ_TEST
@@ -82,7 +83,7 @@ async def test_price_extract(
 @pytest.mark.asyncio
 async def test_price_sensor_attributes():
     """Test data parsing of official API files."""
-    day = datetime.fromisoformat("2023-01-06 09:00:00")
+    day = datetime.fromisoformat("2024-03-09 09:00:00")
     mock_session = MockAsyncSession()
 
     pvpc_data = PVPCData(
@@ -96,14 +97,15 @@ async def test_price_sensor_attributes():
     for key in ALL_SENSORS:
         pvpc_data.process_state_and_attributes(api_data, key, day)
     assert len(api_data.sensors[KEY_PVPC]) == 24
-    assert mock_session.call_count == 4
-    assert len(api_data.sensors) == 4
+    assert mock_session.call_count == 5
+    assert len(api_data.sensors) == 6
 
     ref_data = {
-        KEY_PVPC: {"hours_to_better_price": 1, "num_better_prices_ahead": 6},
-        KEY_INJECTION: {"hours_to_better_price": 5, "num_better_prices_ahead": 5},
-        KEY_MAG: {"hours_to_better_price": 1, "num_better_prices_ahead": 7},
-        KEY_OMIE: {"hours_to_better_price": 1, "num_better_prices_ahead": 6},
+        KEY_PVPC: {"hours_to_better_price": 1, "num_better_prices_ahead": 3},
+        KEY_INJECTION: {"hours_to_better_price": 6, "num_better_prices_ahead": 6},
+        KEY_MAG: {"hours_to_better_price": 1, "num_better_prices_ahead": 11},
+        KEY_OMIE: {"hours_to_better_price": 1, "num_better_prices_ahead": 4},
+        KEY_ADJUSTMENT: {"hours_to_better_price": 1, "num_better_prices_ahead": 2},
     }
 
     for key in ALL_SENSORS:


### PR DESCRIPTION
 En esta PR añado el nuevo indicador para obtener el ajuste de mercado que se realiza en PVPC respecto a la indexada.

Adicionalmente, una vez se tienen todos los sensores, se calcula el valor de indexada durante la fase de procesamiento, restando al valor de PVPC el valor de mercado futuros.

Dado que Indexada no es un indicador, le he puesto 0, aunque no estoy seguro de que deba ser así.