### PR TITLE
Add national holidays for 2026 and 2027; prevent KeyError for unknown years

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,6 @@
 - ✨ Implement **support to access the extended ESIOS API** with a personal token
   (you must request yours by mailing to [consultasios@ree.es](mailto:consultasios@ree.es?subject=Personal%20token%20request)),
   with initial support for the existent PVPC price sensor (ESIOS indicator code: **1001**), and **3 new ones** 🤩:
-
   - **Inyection price** sensor (ESIOS indicator code: **1739**),
     name: "Precio de la energía excedentaria del autoconsumo para el mecanismo de compensación simplificada"
   - **MAG price** sensor (ESIOS indicator code: **1900**),
@@ -108,7 +107,6 @@ with the same information than the current one, available without authentication
   and make `tariff` and `websession` required arguments
 
 - :sparkles: Add alternative data-source from 'apidatos.ree.es'
-
   - Implement data parsing from `apidatos.ree.es`, using endpoint at `/es/datos/mercados/precios-mercados-tiempo-real`
   - Add `data_source` parameter with valid keys 'apidatos' and 'esios_public', setting the new one as default ;-)
   - Remove retry call if 403 status is received, but maintain the User-Agent loop, and also toggle the data-source for the next call

--- a/aiopvpc/pvpc_tariff.py
+++ b/aiopvpc/pvpc_tariff.py
@@ -75,13 +75,40 @@ _NATIONAL_EXTRA_HOLIDAYS_FOR_P3_PERIOD = {
         date(2025, 12, 8): "(lunes), La Inmaculada Concepción",
         date(2025, 12, 25): "(jueves), Navidad",
     },
+    2026: {
+        date(2026, 1, 1): "(jueves), Año nuevo",
+        date(2026, 1, 6): "(martes), Epifanía del Señor",
+        # date(2026, 4, 2): "(jueves), Jueves Santo",
+        date(2026, 4, 3): "(viernes), Viernes Santo",
+        date(2026, 5, 1): "(viernes), Día del Trabajador",
+        # date(2026, 8, 15): "(sábado), Asunción de la Virgen",
+        date(2026, 10, 12): "(lunes), Día de la Hispanidad",
+        # date(2026, 11, 1): "(domingo), Todos los Santos",
+        # date(2026, 12, 6): "(domingo), Día de la Constitución Española",
+        date(2026, 12, 8): "(martes), La Inmaculada Concepción",
+        date(2026, 12, 25): "(viernes), Navidad",
+    },
+    2027: {
+        date(2027, 1, 1): "(viernes), Año nuevo",
+        date(2027, 1, 6): "(miércoles), Epifanía del Señor",
+        # date(2027, 3, 25): "(jueves), Jueves Santo",
+        date(2027, 3, 26): "(viernes), Viernes Santo",
+        # date(2027, 5, 1): "(sábado), Día del Trabajador",
+        # date(2027, 8, 15): "(domingo), Asunción de la Virgen",
+        date(2027, 10, 12): "(martes), Día de la Hispanidad",
+        date(2027, 11, 1): "(lunes), Todos los Santos",
+        date(2027, 12, 6): "(lunes), Día de la Constitución Española",
+        date(2027, 12, 8): "(miércoles), La Inmaculada Concepción",
+        # date(2027, 12, 25): "(sábado), Navidad",
+    },
 }
 
 
 def _tariff_period_key(local_ts: datetime, zone_ceuta_melilla: bool) -> str:
     """Return period key (P1/P2/P3) for current hour."""
     day = local_ts.date()
-    national_holiday = day in _NATIONAL_EXTRA_HOLIDAYS_FOR_P3_PERIOD[day.year]
+    year_holidays = _NATIONAL_EXTRA_HOLIDAYS_FOR_P3_PERIOD.get(day.year, {})
+    national_holiday = day in year_holidays
     if national_holiday or day.isoweekday() >= 6 or local_ts.hour < 8:
         return "P3"
     if zone_ceuta_melilla and local_ts.hour in _HOURS_P2_CYM:


### PR DESCRIPTION
## Problem

`_NATIONAL_EXTRA_HOLIDAYS_FOR_P3_PERIOD` only contains entries up to 2025. Any Home Assistant installation running in 2026 or later raises an unhandled exception when computing the tariff period:

```
KeyError: 2026
  File ".../aiopvpc/pvpc_tariff.py", line 83, in _tariff_period_key
    national_holiday = day in _NATIONAL_EXTRA_HOLIDAYS_FOR_P3_PERIOD[day.year]
```

This causes the `pvpc_hourly_pricing` integration to enter `setup_retry` state and all PVPC sensors to become `unavailable`.

## Changes

### 1. Add 2026 national holidays
Spanish national holidays that affect P3 period computation (weekday-only; weekend dates commented out as they are already P3):

| Date | Day | Holiday |
|------|-----|---------|
| 2026-01-01 | Thursday | Año nuevo |
| 2026-01-06 | Tuesday | Epifanía del Señor |
| 2026-04-03 | Friday | Viernes Santo |
| 2026-05-01 | Friday | Día del Trabajador |
| 2026-10-12 | Monday | Día de la Hispanidad |
| 2026-12-08 | Tuesday | La Inmaculada Concepción |
| 2026-12-25 | Friday | Navidad |

### 2. Add 2027 national holidays
Proactively added to avoid the same issue next year.

### 3. Prevent future `KeyError` for unknown years

Changed `_NATIONAL_EXTRA_HOLIDAYS_FOR_P3_PERIOD[day.year]` to `_NATIONAL_EXTRA_HOLIDAYS_FOR_P3_PERIOD.get(day.year, {})` in `_tariff_period_key()`.

This means installations running in years not yet in the dictionary will fall back to treating all days as non-holidays (conservative behaviour — no tariff period misclassification possible), rather than crashing with an unhandled `KeyError`.

## Testing

Verified manually:
- `_tariff_period_key(datetime(2026, 1, 1, 14, 0), False)` → `P3` ✓ (Año nuevo)
- `_tariff_period_key(datetime(2026, 4, 3, 14, 0), False)` → `P3` ✓ (Viernes Santo)
- `_tariff_period_key(datetime(2026, 4, 6, 14, 0), False)` → `P1` ✓ (normal Monday)
- `_tariff_period_key(datetime(2028, 6, 15, 14, 0), False)` → `P1` ✓ (no KeyError)